### PR TITLE
Multiple security groups and special characters in UNC

### DIFF
--- a/IntuneDriveMapping/Controllers/DriveMappingController.cs
+++ b/IntuneDriveMapping/Controllers/DriveMappingController.cs
@@ -72,7 +72,7 @@ namespace IntuneDriveMapping.Controllers
                 DriveLetter = "A",
                 Label = "Example",
                 Path = "\\\\path\\to\\your\\share",
-                GroupFilter = "exampleGroupSamAccountName"
+                GroupFilter = "exampleGroupSamAccountName,exampleGroup2SamAccountName"
             };
 
             driveMappings.Add(driveMappingModel);

--- a/IntuneDriveMapping/Models/DriveMapping.cs
+++ b/IntuneDriveMapping/Models/DriveMapping.cs
@@ -6,7 +6,7 @@ namespace IntuneDriveMapping.Models
     {
         [Display(Name ="UNC Path")]
         [Required]
-        [RegularExpression(@"^\\\\[a-zA-Z0-9\.\-_\@]{1,}(\\[a-zA-Z0-9\%\$\:\\_\-]{1,}){1,}[\$]{0,1}", ErrorMessage = "Valid UNC path required")]
+        [RegularExpression(@"^\\\\[a-zA-Z0-9\.\-_\@]{1,}(\\[a-zA-Z0-9åäöÅÄÖ\s\%\$\:\\_\-]{1,}){1,}[\$]{0,1}", ErrorMessage = "Valid UNC path required")]
         public string Path { get; set; }
         [Required]
         [RegularExpression(@"^[a-zA-Z]{1}$", ErrorMessage = "Specify single character")]


### PR DESCRIPTION
Added support for multiple security groups like "Group1,Group2"
Added support for space and swedish åäö in the second part of UNCPath eg. the path and not the hostname.